### PR TITLE
VT-5623 Logic Broker Error: Method not found: 'Void CsvHelper.CsvWriter

### DIFF
--- a/src/LogicBrokerAccess/Commands/PostInventoryBroadcastCommand.cs
+++ b/src/LogicBrokerAccess/Commands/PostInventoryBroadcastCommand.cs
@@ -2,6 +2,7 @@
 using LogicBrokerAccess.Models;
 using LogicBrokerAccess.Throttling;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -26,7 +27,7 @@ namespace LogicBrokerAccess.Commands
 		{
 			var sb = new StringBuilder();
 			using ( var writer = new StringWriter( sb ) )
-			using ( var csvWriter = new CsvWriter( writer ) )
+			using ( var csvWriter = new CsvWriter( writer, CultureInfo.InvariantCulture ) )
 			{
 				csvWriter.WriteHeader< LogicBrokerInventoryItem >();
 				csvWriter.NextRecord();

--- a/src/LogicBrokerAccess/LogicBrokerAccess.csproj
+++ b/src/LogicBrokerAccess/LogicBrokerAccess.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="12.0.0" />
+    <PackageReference Include="CsvHelper" Version="27.2.1" />
     <PackageReference Include="CuttingEdge.Conditions" Version="1.2.0" />
     <PackageReference Include="Netco" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/LogicBrokerAccessTests/BaseTest.cs
+++ b/src/LogicBrokerAccessTests/BaseTest.cs
@@ -2,6 +2,7 @@
 using CsvHelper.Configuration;
 using LogicBrokerAccess.Configuration;
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -17,7 +18,7 @@ namespace LogicBrokerAccessTests
 
 		public BaseTest()
 		{
-			var testCredentials = this.LoadTestSettings< TestCredentials >( @"\..\..\credentials.csv" );
+			var testCredentials = this.LoadTestSettings< TestCredentials >( @"\..\..\Files\credentials.csv" );
 			this.Credentials = new LogicBrokerCredentials( testCredentials.SubscriptionKey );
 			this.Config = new LogicBrokerConfig( sandboxDomainUri );
 		}
@@ -28,7 +29,7 @@ namespace LogicBrokerAccessTests
 
 			using ( var streamReader = new StreamReader( basePath + filePath ) )
 			{
-				var csvConfig = new Configuration()
+				var csvConfig = new CsvConfiguration(CultureInfo.InvariantCulture)
 				{
 					Delimiter = ","
 				};

--- a/src/LogicBrokerAccessTests/LogicBrokerAccessTests.csproj
+++ b/src/LogicBrokerAccessTests/LogicBrokerAccessTests.csproj
@@ -35,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CsvHelper, Version=12.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
-      <HintPath>..\packages\CsvHelper.12.2.1\lib\net47\CsvHelper.dll</HintPath>
+    <Reference Include="CsvHelper, Version=27.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
+      <HintPath>..\packages\CsvHelper.27.2.1\lib\net47\CsvHelper.dll</HintPath>
     </Reference>
     <Reference Include="CuttingEdge.Conditions, Version=1.2.0.11174, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
       <HintPath>..\packages\CuttingEdge.Conditions.1.2.0.0\lib\NET35\CuttingEdge.Conditions.dll</HintPath>
@@ -44,6 +44,13 @@
     <Reference Include="FluentAssertions, Version=5.7.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.5.7.0\lib\net47\FluentAssertions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.HashCode, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.HashCode.1.0.0\lib\net461\Microsoft.Bcl.HashCode.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="Netco, Version=2.0.2.0, Culture=neutral, PublicKeyToken=9d732c15ac2ec2c9, processorArchitecture=MSIL">
       <HintPath>..\packages\Netco.2.0.2\lib\net48\Netco.dll</HintPath>
     </Reference>
@@ -54,9 +61,25 @@
       <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.0\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>

--- a/src/LogicBrokerAccessTests/packages.config
+++ b/src/LogicBrokerAccessTests/packages.config
@@ -1,11 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CsvHelper" version="12.2.1" targetFramework="net48" />
+  <package id="CsvHelper" version="27.2.1" targetFramework="net48" />
   <package id="CuttingEdge.Conditions" version="1.2.0.0" targetFramework="net461" />
   <package id="FluentAssertions" version="5.7.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.0.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.HashCode" version="1.0.0" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net48" />
   <package id="Netco" version="2.0.2" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="NUnit" version="3.12.0" targetFramework="net461" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.0" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
[VT-5623]

Difficult reproduce this problem. I googled and found that some people meet this problem and they decrease thier version CsvHelper. But I found that LogicBroker has the super old version of CsvHelper so I think that we should make version CsvHelper is the samme like ChannelsIntegrationDomain in V1. Perhaps it will help.

[VT-5623]: https://agileharbor.atlassian.net/browse/VT-5623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ